### PR TITLE
Update to OpenCV 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,3 +80,5 @@ target_link_libraries(
   compare
   ${OpenCV_LIBS}
   )
+
+install(TARGETS vdff DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,26 +59,26 @@ target_link_libraries(
   )
 
 add_executable(
-  compress
+  vdff-compress
   src/compress.cpp
   src/openCVHelpers.cpp
 )
 
 target_link_libraries(
-  compress
+  vdff-compress
   ${OpenCV_LIBS}
   )
 
 
 add_executable(
-  compare
+  vdff-compare
   src/compare.cpp
   src/openCVHelpers.cpp
 )
 
 target_link_libraries(
-  compare
+  vdff-compare
   ${OpenCV_LIBS}
   )
 
-install(TARGETS vdff DESTINATION bin)
+install(TARGETS vdff vdff-compress vdff-compare DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Möller, Michael et al. ["Variational Depth From Focus Reconstruction.”](http:
 CMake, CUDA, OpenCV
 
 #### MacOSX (10.9, 10.10)
+See commit 17226b9648f11d41b915cd060f9af636d4e106de for OpenCV 2.4 support.
+
 We installed OpenCV 2.4.10 and CMake 3 using brew
 
 make sure brew is installed correctly
@@ -34,7 +36,7 @@ http://developer.download.nvidia.com/compute/cuda/7_0/Prod/local_installers/cuda
 
 
 #### Linux
-Our code was tested under Arch Linux with OpenCV 2.4.10, CMake 3.2.1 and CUDA 7.0.
+Our code was tested under Arch Linux with OpenCV 4.1.0, CMake 3.14.3 and CUDA 10.1.105.
 It should compile and run successfully under your favorite linux distribution if it provides the above mentioned dependencies.
 
 Please use the appropriate package manager of your distribution to install these packages; below is an example
@@ -46,8 +48,12 @@ pacman -S cmake
 pacman -S cuda
 ```
 
+Additionally, a [PKGBUILD](https://raw.githubusercontent.com/Crystalix007/PersonalAUR/master/variational-depth-from-focus/PKGBUILD) is provided for Arch Linux users.
+
 #### Windows
-The code was tested under Windows 8.1, OpenCV 2.4.10, CMake 3.2.1, CUDA 7.0 and assumes you have a working version of Visual Studio installed.In our case, we worked with Visual Studio Ultimate 2013. 
+See commit 17226b9648f11d41b915cd060f9af636d4e106de for OpenCV 2.4 support.
+
+The code was tested under Windows 8.1, OpenCV 2.4.10, CMake 3.2.1, CUDA 7.0 and assumes you have a working version of Visual Studio installed. In our case, we worked with Visual Studio Ultimate 2013. 
 
 If you do not have a version of Visual Studio, it is recommended that you install it first.
 One can obtain a free version under the following link:
@@ -220,7 +226,7 @@ After the capture, a burst of images is saved in the folder
 ```sh
 Pictures/devCam/Captured/<capture design id>
 ```
-For copying the json file to the device and copying the captured image folder back to the PC one can use the MTP based [Android File Transfer](https://www.android.com/filetransfer/) on MAC. Note that if new folders/files don't show up, just restart the Android File Transfer program and if that doesn't help, restart the phone.
+For copying the json file to the device and copying the captured image folder back to the PC one can use the MTP based [Android File Transfer](https://www.android.com/filetransfer/) on Mac. Note that if new folders/files don't show up, just restart the Android File Transfer program and if that doesn't help, restart the phone.
 
 Since varying the focal distance also changes the field of view, corresponding pixels will no longer be aligned. This effect can be removed by aligning all the images and optimizing the field of view for all images using the [align image stack](http://hugin.sourceforge.net/docs/manual/Align_image_stack.html) of [hugin](http://hugin.sourceforge.net/). This outputs tiff images, to save space one can convert them back to jpg using the compress application provided in our repository.
 ```sh
@@ -232,13 +238,13 @@ cd <capture design id>
 cd ..
 ../build/compress -compr 95 -indir ../aligned/<capture design id> -outdir ../samples/<capture design id> -type jpg -color 1 -anydepth 1 -debug 0
 ```
-note that when using the sweep_focus.json file which ships with the app instead of the one we provide above, the order of focal distances is reversed, meaning that the first captured image has the largest focal distance. In this case, just pass -r to sort so that the images will be cropped correctly and the resulting depth colormap is in the same order as in the other sequences.
+Note that when using the sweep_focus.json file, which ships with the app, instead of the one we provide above, the order of focal distances is reversed, meaning that the first captured image has the largest focal distance. In this case, just pass -r to sort so that the images will be cropped correctly and the resulting depth colormap is in the same order as in the other sequences.
 
 For convenience, we provide the bash script [align.sh](https://github.com/adrelino/variational-depth-from-focus/blob/master/align.sh) which bundles all of the above tasks, and additionally calls the main vdff programm together with the export option to quickly check if a recorded burst gives a satisfying depth map.
 
-considered you copied the Captured folder to the root of this github repository, then you simply need to run
+Once you have copied the Captured folder to the root of this github repository, then you simply need to run:
 ```sh
 cd <vddf repo root>/Captured
 ../align.sh <capture design id> <reverse>?
 ```
-which aligns the images, optionally reversing them if a second argument is supplied, crops them, compresses them and stores them in the /samples/<capture design id> folder and then runs the main vdff programm with this sequence, exporting the resulting depth map to /samples/results/<capture design id>.png.
+This aligns the images, optionally reversing them if a second argument is supplied, crops them, compresses them and stores them in the /samples/<capture design id> folder and then runs the main vdff programm with this sequence, exporting the resulting depth map to /samples/results/<capture design id>.png.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Möller, Michael et al. ["Variational Depth From Focus Reconstruction.”](http:
 CMake, CUDA, OpenCV
 
 #### MacOSX (10.9, 10.10)
-See commit 17226b9648f11d41b915cd060f9af636d4e106de for OpenCV 2.4 support.
+See commit [17226b9](https://github.com/adrelino/variational-depth-from-focus/commit/17226b9648f11d41b915cd060f9af636d4e106de) for OpenCV 2.4 support.
 
 We installed OpenCV 2.4.10 and CMake 3 using brew
 
@@ -51,7 +51,7 @@ pacman -S cuda
 Additionally, a [PKGBUILD](https://raw.githubusercontent.com/Crystalix007/PersonalAUR/master/variational-depth-from-focus/PKGBUILD) is provided for Arch Linux users.
 
 #### Windows
-See commit 17226b9648f11d41b915cd060f9af636d4e106de for OpenCV 2.4 support.
+See commit [17226b9](https://github.com/adrelino/variational-depth-from-focus/commit/17226b9648f11d41b915cd060f9af636d4e106de) for OpenCV 2.4 support.
 
 The code was tested under Windows 8.1, OpenCV 2.4.10, CMake 3.2.1, CUDA 7.0 and assumes you have a working version of Visual Studio installed. In our case, we worked with Visual Studio Ultimate 2013. 
 

--- a/include/DataPreparator.cuh
+++ b/include/DataPreparator.cuh
@@ -19,6 +19,7 @@
 #define DATA_PREPARATOR_H
 
 #include <utils.cuh>
+#undef id
 #include <opencv2/opencv.hpp>
 
 namespace vdff {

--- a/include/DataPreparator.cuh
+++ b/include/DataPreparator.cuh
@@ -19,8 +19,11 @@
 #define DATA_PREPARATOR_H
 
 #include <utils.cuh>
+
+#pragma push_macro("id")
 #undef id
 #include <opencv2/opencv.hpp>
+#pragma pop_macro("id")
 
 namespace vdff {
   typedef enum{

--- a/src/compare.cpp
+++ b/src/compare.cpp
@@ -24,8 +24,8 @@ int main(int argc, char **argv) {
 
 
 
-        cv::Mat depthFromGray = cv::imread(im1,CV_LOAD_IMAGE_UNCHANGED);
-        cv::Mat depthFromColor = cv::imread(im2,CV_LOAD_IMAGE_UNCHANGED);
+        cv::Mat depthFromGray = cv::imread(im1,cv::IMREAD_UNCHANGED);
+        cv::Mat depthFromColor = cv::imread(im2,cv::IMREAD_UNCHANGED);
 
         cout<<"im1: ";
         openCVHelpers::imgInfo(depthFromGray,true);

--- a/src/compare.cpp
+++ b/src/compare.cpp
@@ -33,15 +33,17 @@ int main(int argc, char **argv) {
         openCVHelpers::imgInfo(depthFromColor,true);
 
         cv::Mat diff = abs(depthFromColor-depthFromGray);
-        cout<<endl<<"diff: ";
-        openCVHelpers::imgInfo(diff,true);
 
         double min,max;
         cv::minMaxLoc(diff,&min,&max);
         float scale = 255.0f / (max - min);
         cv::Mat depthMap;
         diff.convertTo(depthMap, CV_8UC1, scale, -min*scale);
+        diff.convertTo(diff, CV_32FC1);
 
+        cout<<endl<<"diff: ";
+        openCVHelpers::imgInfo(diff,true);
+        cout.flush();
 
         cv::imshow("diff",depthMap);
         imwrite(imdiff+".png",depthMap);

--- a/src/compare.cpp
+++ b/src/compare.cpp
@@ -1,15 +1,17 @@
 // opencv stuff
+#include <iostream>
+using namespace std;
+
+
 #include <opencv2/opencv.hpp>
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
-#include <opencv2/contrib/contrib.hpp>
+//#include <opencv2/contrib/contrib.hpp>
 
 #include "openCVHelpers.h"
 
-#include <iostream>
 
 using namespace vdff;
-using namespace std;
 using namespace Utils;
 
 int main(int argc, char **argv) {

--- a/src/compress.cpp
+++ b/src/compress.cpp
@@ -35,15 +35,15 @@ int main(int argc, char **argv) {
     getParam("type", type, argc, argv);
 
 //    /* 8bit, color or not */
-//        CV_LOAD_IMAGE_UNCHANGED  =-1,
+//        cv::IMREAD_UNCHANGED  =-1,
 //    /* 8bit, gray */
-//        CV_LOAD_IMAGE_GRAYSCALE  =0,
+//        cv::IMREAD_GRAYSCALE  =0,
 //    /* ?, color */
-//        CV_LOAD_IMAGE_COLOR      =1,
+//        cv::IMREAD_COLOR      =1,
 //    /* any depth, ? */
-//        CV_LOAD_IMAGE_ANYDEPTH   =2,
+//        cv::IMREAD_ANYDEPTH   =2,
 //    /* ?, any color */
-//        CV_LOAD_IMAGE_ANYCOLOR   =4
+//        cv::IMREAD_ANYCOLOR   =4
 
     bool color = 0;
     bool anydepth = 0;
@@ -70,9 +70,9 @@ int main(int argc, char **argv) {
     for(int i=0; i<images.size(); i+=step){
         cv::Mat image;
         if(unchanged){
-            image = cv::imread(images[i],IMREAD_UNCHANGED);
+            image = cv::imread(images[i],cv::IMREAD_UNCHANGED);
         }else{
-            image = cv::imread(images[i], (IMREAD_COLOR & color*255 ) | (IMREAD_ANYDEPTH & anydepth*255) | (IMREAD_ANYCOLOR & anycolor*255) );
+            image = cv::imread(images[i],(cv::IMREAD_COLOR & color*255 ) | (cv::IMREAD_ANYDEPTH & anydepth*255) | (cv::IMREAD_ANYCOLOR & anycolor*255) );
         }
 
         if(debug) cv::imshow("in",image);
@@ -94,7 +94,7 @@ int main(int argc, char **argv) {
         //http://docs.opencv.org/modules/highgui/doc/reading_and_writing_images_and_video.html#imwrite
         //Only 8-bit (or 16-bit unsigned (CV_16U) in case of PNG, JPEG 2000, and TIFF) single-channel or 3-channel (with ‘BGR’ channel order) images can be saved using this function.
         if(type == "jpg"){
-           params.push_back(IMWRITE_JPEG_QUALITY);
+           params.push_back(cv::IMWRITE_JPEG_QUALITY);
            params.push_back(compr);   // that's percent, so 100 == no compression, 1 == full
            int maxRange = MAX_RANGE(image);
            if(maxRange>255){
@@ -102,7 +102,7 @@ int main(int argc, char **argv) {
                image.convertTo(image,CV_8U,scaleFactor); //jpg only supports 8 bit,
            }
         }else if (type == "png"){
-           params.push_back(IMWRITE_PNG_COMPRESSION);
+           params.push_back(cv::IMWRITE_PNG_COMPRESSION);
            params.push_back(compr);   // that's compression level, 9 == full , 0 == none
         }else if (type == "exr"){
             //exr can save 32 bit float
@@ -122,7 +122,7 @@ int main(int argc, char **argv) {
         cv::imwrite(outname,image,params);
 
         if(debug){
-            image = cv::imread(outname,IMREAD_UNCHANGED);
+            image = cv::imread(outname,cv::IMREAD_UNCHANGED);
             cv::imshow("saved",image);
             cout<<"saved: ";
             openCVHelpers::imgInfo(image);

--- a/src/compress.cpp
+++ b/src/compress.cpp
@@ -1,17 +1,19 @@
 
 // opencv stuff
+#include <iostream>
+using namespace std;
+
+
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
-#include <opencv2/contrib/contrib.hpp>
+//#include <opencv2/contrib/contrib.hpp>
 
 #include "openCVHelpers.h"
 
-#include <iostream>
 
 #include <sys/stat.h>
 
 using namespace vdff;
-using namespace std;
 using namespace Utils;
 
 int main(int argc, char **argv) {

--- a/src/compress.cpp
+++ b/src/compress.cpp
@@ -70,9 +70,9 @@ int main(int argc, char **argv) {
     for(int i=0; i<images.size(); i+=step){
         cv::Mat image;
         if(unchanged){
-            image = cv::imread(images[i],CV_LOAD_IMAGE_UNCHANGED);
+            image = cv::imread(images[i],IMREAD_UNCHANGED);
         }else{
-            image = cv::imread(images[i], (CV_LOAD_IMAGE_COLOR & color*255 ) | (CV_LOAD_IMAGE_ANYDEPTH & anydepth*255) | (CV_LOAD_IMAGE_ANYCOLOR & anycolor*255) );
+            image = cv::imread(images[i], (IMREAD_COLOR & color*255 ) | (IMREAD_ANYDEPTH & anydepth*255) | (IMREAD_ANYCOLOR & anycolor*255) );
         }
 
         if(debug) cv::imshow("in",image);
@@ -94,7 +94,7 @@ int main(int argc, char **argv) {
         //http://docs.opencv.org/modules/highgui/doc/reading_and_writing_images_and_video.html#imwrite
         //Only 8-bit (or 16-bit unsigned (CV_16U) in case of PNG, JPEG 2000, and TIFF) single-channel or 3-channel (with ‘BGR’ channel order) images can be saved using this function.
         if(type == "jpg"){
-           params.push_back(CV_IMWRITE_JPEG_QUALITY);
+           params.push_back(IMWRITE_JPEG_QUALITY);
            params.push_back(compr);   // that's percent, so 100 == no compression, 1 == full
            int maxRange = MAX_RANGE(image);
            if(maxRange>255){
@@ -102,7 +102,7 @@ int main(int argc, char **argv) {
                image.convertTo(image,CV_8U,scaleFactor); //jpg only supports 8 bit,
            }
         }else if (type == "png"){
-           params.push_back(CV_IMWRITE_PNG_COMPRESSION);
+           params.push_back(IMWRITE_PNG_COMPRESSION);
            params.push_back(compr);   // that's compression level, 9 == full , 0 == none
         }else if (type == "exr"){
             //exr can save 32 bit float
@@ -122,7 +122,7 @@ int main(int argc, char **argv) {
         cv::imwrite(outname,image,params);
 
         if(debug){
-            image = cv::imread(outname,CV_LOAD_IMAGE_UNCHANGED);
+            image = cv::imread(outname,IMREAD_UNCHANGED);
             cv::imshow("saved",image);
             cout<<"saved: ";
             openCVHelpers::imgInfo(image);

--- a/src/openCVHelpers.cpp
+++ b/src/openCVHelpers.cpp
@@ -14,14 +14,13 @@
 // ### Dennis Mack, dennis.mack@tum.de, p060
 // ### Adrian Haarbach, haarbach@in.tum.de, p077
 // ### Markus Schlaffer, markus.schlaffer@in.tum.de, p070
+#include <iostream>
+using namespace std;
 
 #include <openCVHelpers.h>
-#include <opencv2/contrib/contrib.hpp>
-
-#include <iostream>
+//#include <opencv2/contrib/contrib.hpp>
 
 using namespace cv;
-using namespace std;
 
 namespace vdff {
 

--- a/src/openCVHelpers.cpp
+++ b/src/openCVHelpers.cpp
@@ -232,8 +232,8 @@ namespace vdff {
     void showImage(const string &title, const cv::Mat &mat, int x, int y)
     {
       const char *wTitle = title.c_str();
-      cv::namedWindow(wTitle, CV_WINDOW_AUTOSIZE);
-      cvMoveWindow(wTitle, x, y);
+      cv::namedWindow(wTitle, cv::WINDOW_AUTOSIZE);
+      cv::moveWindow(wTitle, x, y);
       cv::imshow(wTitle, mat);
     }
 
@@ -287,10 +287,10 @@ namespace vdff {
 
       Mat scaled = mat;
       Mat meanCols;
-      reduce(mat, meanCols, 0, CV_REDUCE_AVG );
+      reduce(mat, meanCols, 0, cv::REDUCE_AVG);
 
       Mat mean;
-      reduce(meanCols, mean, 1, CV_REDUCE_AVG);
+      reduce(meanCols, mean, 1, cv::REDUCE_AVG);
     
       cout << "Max value: " << max << endl;
       cout << "Mean value: " << mean.at<float>(0) << endl;
@@ -401,9 +401,9 @@ void imgInfo(cv::Mat image,bool full){
 }
 
 Mat imreadFloat(string filename,bool grayscale){
-    int flags = CV_LOAD_IMAGE_UNCHANGED;
+    int flags = cv::IMREAD_UNCHANGED;
 //    if(openCVHelpers::color) flags = CV_LOAD_IMAGE_ANYDEPTH | CV_LOAD_IMAGE_COLOR;
-    if(grayscale) flags = CV_LOAD_IMAGE_ANYDEPTH | CV_LOAD_IMAGE_GRAYSCALE;
+    if(grayscale) flags = cv::IMREAD_ANYDEPTH | cv::IMREAD_GRAYSCALE;
 
     cv::Mat original = imread(filename,flags);
     //cout<<endl;


### PR DESCRIPTION
Updates OpenCV framework to version 4.1.0.

Working on Arch Linux with CMake 3.14.3 and CUDA 10.1.105.

Closes #5.

Needs testing for building on Windows and OSX.